### PR TITLE
Fix a bug in the SSE implementation which would cause a crash if the des...

### DIFF
--- a/src/freak.cpp
+++ b/src/freak.cpp
@@ -428,7 +428,7 @@ void FREAKImpl::compute( const Mat& image, std::vector<KeyPoint>& keypoints, Mat
                 (*ptr) = result128;
                 ++ptr;
             }
-            ptr-=8;
+            ptr -= (FREAK_NB_PAIRS/128)*2;
 #else
             for( int m = CV_FREAK_NB_PAIRS; m--; ) {
                 ptr->set(m, pointsValue[descriptionPairs[m].i]>  pointsValue[descriptionPairs[m].j ] );


### PR DESCRIPTION
Fix a bug in the SSE implementation which would cause a crash if the descriptor wasn't comprised for 512 pairs.

Further information is here:

http://code.opencv.org/issues/3889
